### PR TITLE
Async Lookups

### DIFF
--- a/src/main/java/cf/dejf/DEJFVPNBlocker/DEJFVPNBlocker.java
+++ b/src/main/java/cf/dejf/DEJFVPNBlocker/DEJFVPNBlocker.java
@@ -43,7 +43,7 @@ public class DEJFVPNBlocker extends JavaPlugin {
         pluginName = pdf.getName();
         log.info("[" + pluginName + "] Loading plugin version " + pdf.getVersion());
 
-        this.getServer().getPluginManager().registerEvent(Event.Type.PLAYER_JOIN, new PlayerJoinListener(), Event.Priority.Normal, this);
+        this.getServer().getPluginManager().registerEvent(Event.Type.PLAYER_JOIN, new PlayerJoinListener(plugin), Event.Priority.Normal, this);
         this.getCommand("vpnblocker").setExecutor(this);
         ConfigManager.load();
 

--- a/src/main/java/cf/dejf/DEJFVPNBlocker/PlayerJoinListener.java
+++ b/src/main/java/cf/dejf/DEJFVPNBlocker/PlayerJoinListener.java
@@ -1,60 +1,79 @@
 package cf.dejf.DEJFVPNBlocker;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerListener;
+import org.bukkit.event.player.PlayerLoginEvent;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.logging.Level;
 
 import static cf.dejf.DEJFVPNBlocker.DEJFVPNBlocker.*;
 
 public class PlayerJoinListener extends PlayerListener {
+    private DEJFVPNBlocker plugin;
+
+
+    public PlayerJoinListener(DEJFVPNBlocker plugin) {
+        this.plugin = plugin;
+    }
+
 
     @Override
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        String playerIp = "0.0.0.0";
-
-        if(player.getAddress().getHostName() != null) {
-            playerIp = player.getAddress().getHostName();
-        }
+        final String playerIp = player.getAddress().getAddress().getHostAddress();
 
         System.out.println("[DEJFVPNBlocker] Player " + player.getName() + " is trying to join from IP " + playerIp);
 
-        try {
-            boolean isVPN;
-
-            if(ipLog.containsKey(playerIp)) {
-                IPLogEntry ipLogEntry = ipLog.get(playerIp);
-                isVPN = ipLogEntry.isVPN();
-                System.out.println("[DEJFVPNBlocker] This IP was found in the local database (i.e. it belongs to an active user).");
-            } else {
-                isVPN = HTTPRequester.checkIp(playerIp);
-                ipLog.put(playerIp, new IPLogEntry(isVPN, new Date()));
-                ConfigManager.saveDatabase();
-                System.out.println("[DEJFVPNBlocker] This IP was not found in the local database (i.e. it is new or the database has cleared itself recently).");
-            }
-
-            if(isVPN) {
+        //Check Blacklist
+        if (blacklistedIps.contains(playerIp)) {
+            System.out.println("[DEJFVPNBlocker] This IP has been blacklisted in the plugin configuration!");
+            player.kickPlayer(blacklistKickMessage);
+            return;
+        }
+        if (ipLog.containsKey(playerIp)) {
+            IPLogEntry ipLogEntry = ipLog.get(playerIp);
+            System.out.println("[DEJFVPNBlocker] This IP was found in the local database (i.e. it belongs to an active user).");
+            if (ipLogEntry.isVPN()) {
                 System.out.println("[DEJFVPNBlocker] This player is on a VPN!");
-                if(whitelistedIps.contains(playerIp)) {
+                if (whitelistedIps.contains(playerIp)) {
                     System.out.println("[DEJFVPNBlocker] This player will not be kicked as their IP has been whitelisted in the plugin configuration.");
                 } else {
                     player.kickPlayer(vpnKickMessage);
                 }
-            } else {
-                System.out.println("[DEJFVPNBlocker] This player is most likely not on a VPN.");
             }
-
-            if(blacklistedIps.contains(playerIp)) {
-                System.out.println("[DEJFVPNBlocker] This IP has been blacklisted in the plugin configuration!");
-                player.kickPlayer(blacklistKickMessage);
-            }
-
-        } catch (IOException e) {
-            e.printStackTrace();
+            return;
         }
+        System.out.println("[DEJFVPNBlocker] This IP was not found in the local database (i.e. it is new or the database has cleared itself recently).");
+
+        //Run the lookup Async, so the main server thread isn't frozen.
+        Bukkit.getServer().getScheduler().scheduleAsyncDelayedTask(plugin, () -> {
+            try {
+                final boolean isVPN = HTTPRequester.checkIp(playerIp);
+                //Carry out the following actions synchronously
+                Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+                    ipLog.put(playerIp, new IPLogEntry(isVPN, new Date()));
+                    ConfigManager.saveDatabase();
+                    if (isVPN) {
+                        System.out.println("[DEJFVPNBlocker] This player is on a VPN!");
+                        if (whitelistedIps.contains(playerIp)) {
+                            System.out.println("[DEJFVPNBlocker] This player will not be kicked as their IP has been whitelisted in the plugin configuration.");
+                        } else {
+                            player.kickPlayer(vpnKickMessage);
+                        }
+                    } else {
+                        System.out.println("[DEJFVPNBlocker] This player is most likely not on a VPN.");
+                    }
+                }, 0L);
+            } catch (IOException e) {
+                plugin.getServer().getLogger().log(Level.WARNING, "[DEJFVPNBlocker] Error occurred attempting to get details for IP: " + playerIp, e);
+            }
+        }, 0L);
+
+
     }
 
 }

--- a/src/main/java/plugin.yml
+++ b/src/main/java/plugin.yml
@@ -1,5 +1,5 @@
 name: DEJFVPNBlocker
-version: 1.2
+version: 1.3
 main: cf.dejf.DEJFVPNBlocker.DEJFVPNBlocker
 commands:
   vpnblocker:


### PR DESCRIPTION
- Made any lookups done Async. Although this may allow a player to connect for a few hundred milliseconds, it is better than halting the main server thread which can cause drastic TPS drops.
- Get player address, and not a hostname. This also removes the need for a null check.
- Increment version to 1.3